### PR TITLE
generic: fix probe issues with RealTek RTL8221B PHYs

### DIFF
--- a/target/linux/generic/pending-6.6/720-07-net-phy-realtek-mark-existing-MMDs-as-present.patch
+++ b/target/linux/generic/pending-6.6/720-07-net-phy-realtek-mark-existing-MMDs-as-present.patch
@@ -1,0 +1,27 @@
+From 1addfb042a9d27788a0fb2c2935045b56fd8560e Mon Sep 17 00:00:00 2001
+From: Daniel Golle <daniel@makrotopia.org>
+Date: Thu, 23 Jan 2025 03:25:29 +0000
+Subject: [PATCH] net: phy: realtek: mark existing MMDs as present
+
+When using Clause-45 mode to access RealTek RTL8221B 2.5G PHYs some
+versions of the PHY fail to report the MMDs present on the PHY.
+Mark MMDs PMAPMD, PCS and AN which are always existing according to
+the datasheet as present to fix that.
+
+Signed-off-by: Daniel Golle <daniel@makrotopia.org>
+---
+ drivers/net/phy/realtek/realtek_main.c | 3 +++
+ 1 file changed, 3 insertions(+)
+
+--- a/drivers/net/phy/realtek/realtek_main.c
++++ b/drivers/net/phy/realtek/realtek_main.c
+@@ -1034,6 +1034,9 @@ static int rtl822x_c45_get_features(stru
+ 	linkmode_set_bit(ETHTOOL_LINK_MODE_TP_BIT,
+ 			 phydev->supported);
+ 
++	phydev->c45_ids.mmds_present |= MDIO_DEVS_PMAPMD | MDIO_DEVS_PCS |
++				        MDIO_DEVS_AN;
++
+ 	return genphy_c45_pma_read_abilities(phydev);
+ }
+ 


### PR DESCRIPTION
Import patch "net: phy: realtek: mark existing MMDs as present"

    When using Clause-45 mode to access RealTek RTL8221B 2.5G PHYs some
    versions of the PHY fail to report the MMDs present on the PHY.
    Mark MMDs PMAPMD, PCS and AN which are always existing according to
    the datasheet as present to fix that.

Fixes: #16823, #17183, #17232

Tested-by: Aleksander Jan Bajkowski <olek2@wp.pl>
Tested-by: Juan Pedro Paredes Caballero <juanpedro.paredes@gmail.com>

Thanks for your contribution to OpenWrt!

To help keep the codebase consistent and readable,
and to help people review your contribution,
we ask you to follow the rules you find in the wiki at this link
https://openwrt.org/submitting-patches

Please remove this message before posting the pull request.

## Summary by Sourcery

Bug Fixes:
- Fix issues with RealTek RTL8221B PHYs failing to report MMDs in Clause-45 mode.