### PR TITLE
Merge changes 

### DIFF
--- a/package/network/services/hostapd/src/src/ap/ucode.c
+++ b/package/network/services/hostapd/src/src/ap/ucode.c
@@ -362,8 +362,10 @@ uc_hostapd_iface_add_bss(uc_vm_t *vm, size_t nargs)
 
 	hapd->driver = iface->bss[0]->driver;
 	hapd->drv_priv = iface->bss[0]->drv_priv;
+#ifdef CONFIG_IEEE80211BE
 	os_strlcpy(hapd->ctrl_sock_iface, hapd->conf->iface,
 		   sizeof(hapd->ctrl_sock_iface));
+#endif
 	if (interfaces->ctrl_iface_init &&
 	    interfaces->ctrl_iface_init(hapd) < 0)
 		goto free_hapd;

--- a/package/network/services/hostapd/src/src/ap/ucode.c
+++ b/package/network/services/hostapd/src/src/ap/ucode.c
@@ -362,6 +362,8 @@ uc_hostapd_iface_add_bss(uc_vm_t *vm, size_t nargs)
 
 	hapd->driver = iface->bss[0]->driver;
 	hapd->drv_priv = iface->bss[0]->drv_priv;
+	os_strlcpy(hapd->ctrl_sock_iface, hapd->conf->iface,
+		   sizeof(hapd->ctrl_sock_iface));
 	if (interfaces->ctrl_iface_init &&
 	    interfaces->ctrl_iface_init(hapd) < 0)
 		goto free_hapd;

--- a/package/network/services/hostapd/src/src/ap/ucode.c
+++ b/package/network/services/hostapd/src/src/ap/ucode.c
@@ -59,7 +59,7 @@ hostapd_ucode_update_bss_list(struct hostapd_iface *iface, uc_value_t *if_bss, u
 		ucv_array_set(list, i, ucv_string_new(hapd->conf->iface));
 		ucv_object_add(bss, hapd->conf->iface, ucv_get(val));
 	}
-	ucv_object_add(if_bss, iface->phy, ucv_get(list));
+	ucv_object_add(if_bss, iface->phy, list);
 }
 
 static void
@@ -77,9 +77,10 @@ hostapd_ucode_update_interfaces(void)
 		hostapd_ucode_update_bss_list(iface, if_bss, bss);
 	}
 
-	ucv_object_add(ucv_prototype_get(global), "interfaces", ucv_get(ifs));
-	ucv_object_add(ucv_prototype_get(global), "interface_bss", ucv_get(if_bss));
-	ucv_object_add(ucv_prototype_get(global), "bss", ucv_get(bss));
+	ucv_object_add(ucv_prototype_get(global), "interfaces", ifs);
+	ucv_object_add(ucv_prototype_get(global), "interface_bss", if_bss);
+	ucv_object_add(ucv_prototype_get(global), "bss", bss);
+
 	ucv_gc(vm);
 }
 

--- a/package/network/services/hostapd/src/src/ap/ucode.c
+++ b/package/network/services/hostapd/src/src/ap/ucode.c
@@ -23,7 +23,7 @@ hostapd_ucode_bss_get_uval(struct hostapd_data *hapd)
 	uc_value_t *val;
 
 	if (hapd->ucode.idx)
-		return wpa_ucode_registry_get(bss_registry, hapd->ucode.idx);
+		return ucv_get(wpa_ucode_registry_get(bss_registry, hapd->ucode.idx));
 
 	val = uc_resource_new(bss_type, hapd);
 	hapd->ucode.idx = wpa_ucode_registry_add(bss_registry, val);
@@ -37,7 +37,7 @@ hostapd_ucode_iface_get_uval(struct hostapd_iface *hapd)
 	uc_value_t *val;
 
 	if (hapd->ucode.idx)
-		return wpa_ucode_registry_get(iface_registry, hapd->ucode.idx);
+		return ucv_get(wpa_ucode_registry_get(iface_registry, hapd->ucode.idx));
 
 	val = uc_resource_new(iface_type, hapd);
 	hapd->ucode.idx = wpa_ucode_registry_add(iface_registry, val);
@@ -54,10 +54,9 @@ hostapd_ucode_update_bss_list(struct hostapd_iface *iface, uc_value_t *if_bss, u
 	list = ucv_array_new(vm);
 	for (i = 0; iface->bss && i < iface->num_bss; i++) {
 		struct hostapd_data *hapd = iface->bss[i];
-		uc_value_t *val = hostapd_ucode_bss_get_uval(hapd);
 
 		ucv_array_set(list, i, ucv_string_new(hapd->conf->iface));
-		ucv_object_add(bss, hapd->conf->iface, ucv_get(val));
+		ucv_object_add(bss, hapd->conf->iface, hostapd_ucode_bss_get_uval(hapd));
 	}
 	ucv_object_add(if_bss, iface->phy, list);
 }
@@ -73,7 +72,7 @@ hostapd_ucode_update_interfaces(void)
 	for (i = 0; i < interfaces->count; i++) {
 		struct hostapd_iface *iface = interfaces->iface[i];
 
-		ucv_object_add(ifs, iface->phy, ucv_get(hostapd_ucode_iface_get_uval(iface)));
+		ucv_object_add(ifs, iface->phy, hostapd_ucode_iface_get_uval(iface));
 		hostapd_ucode_update_bss_list(iface, if_bss, bss);
 	}
 
@@ -932,6 +931,7 @@ void hostapd_ucode_bss_cb(struct hostapd_data *hapd, const char *type)
 	uc_value_push(ucv_string_new(hapd->conf->iface));
 	uc_value_push(ucv_get(val));
 	ucv_put(wpa_ucode_call(3));
+	ucv_put(val);
 	ucv_gc(vm);
 }
 
@@ -966,6 +966,7 @@ void hostapd_ucode_apup_newpeer(struct hostapd_data *hapd, const char *ifname)
 	uc_value_push(ucv_get(val));
 	uc_value_push(ucv_string_new(ifname)); // APuP peer ifname
 	ucv_put(wpa_ucode_call(2));
+	ucv_put(val);
 	ucv_gc(vm);
 }
 #endif // def CONFIG_APUP

--- a/package/network/services/hostapd/src/src/ap/ucode.c
+++ b/package/network/services/hostapd/src/src/ap/ucode.c
@@ -56,7 +56,7 @@ hostapd_ucode_update_bss_list(struct hostapd_iface *iface, uc_value_t *if_bss, u
 		struct hostapd_data *hapd = iface->bss[i];
 		uc_value_t *val = hostapd_ucode_bss_get_uval(hapd);
 
-		ucv_array_set(list, i, ucv_get(ucv_string_new(hapd->conf->iface)));
+		ucv_array_set(list, i, ucv_string_new(hapd->conf->iface));
 		ucv_object_add(bss, hapd->conf->iface, ucv_get(val));
 	}
 	ucv_object_add(if_bss, iface->phy, ucv_get(list));
@@ -721,11 +721,10 @@ int hostapd_ucode_sta_auth(struct hostapd_data *hapd, struct sta_info *sta)
 	if (wpa_ucode_call_prepare("sta_auth"))
 		return 0;
 
-	uc_value_push(ucv_get(ucv_string_new(hapd->conf->iface)));
+	uc_value_push(ucv_string_new(hapd->conf->iface));
 
 	snprintf(addr, sizeof(addr), MACSTR, MAC2STR(sta->addr));
-	val = ucv_string_new(addr);
-	uc_value_push(ucv_get(val));
+	uc_value_push(ucv_string_new(addr));
 
 	val = wpa_ucode_call(2);
 
@@ -787,16 +786,15 @@ void hostapd_ucode_sta_connected(struct hostapd_data *hapd, struct sta_info *sta
 	if (wpa_ucode_call_prepare("sta_connected"))
 		return;
 
-	uc_value_push(ucv_get(ucv_string_new(hapd->conf->iface)));
+	uc_value_push(ucv_string_new(hapd->conf->iface));
 
 	snprintf(addr, sizeof(addr), MACSTR, MAC2STR(sta->addr));
-	val = ucv_string_new(addr);
-	uc_value_push(ucv_get(val));
+	uc_value_push(ucv_string_new(addr));
 
 	val = ucv_object_new(vm);
 	if (sta->psk_idx)
 		ucv_object_add(val, "psk_idx", ucv_int64_new(sta->psk_idx - 1));
-	uc_value_push(ucv_get(val));
+	uc_value_push(val);
 
 	val = wpa_ucode_call(3);
 	if (ucv_type(val) != UC_OBJECT)
@@ -929,8 +927,8 @@ void hostapd_ucode_bss_cb(struct hostapd_data *hapd, const char *type)
 		return;
 
 	val = hostapd_ucode_bss_get_uval(hapd);
-	uc_value_push(ucv_get(ucv_string_new(hapd->iface->phy)));
-	uc_value_push(ucv_get(ucv_string_new(hapd->conf->iface)));
+	uc_value_push(ucv_string_new(hapd->iface->phy));
+	uc_value_push(ucv_string_new(hapd->conf->iface));
 	uc_value_push(ucv_get(val));
 	ucv_put(wpa_ucode_call(3));
 	ucv_gc(vm);
@@ -963,9 +961,9 @@ void hostapd_ucode_apup_newpeer(struct hostapd_data *hapd, const char *ifname)
 		return;
 
 	val = hostapd_ucode_bss_get_uval(hapd);
-	uc_value_push(ucv_get(ucv_string_new(hapd->conf->iface))); // BSS ifname
+	uc_value_push(ucv_string_new(hapd->conf->iface)); // BSS ifname
 	uc_value_push(ucv_get(val));
-	uc_value_push(ucv_get(ucv_string_new(ifname))); // APuP peer ifname
+	uc_value_push(ucv_string_new(ifname)); // APuP peer ifname
 	ucv_put(wpa_ucode_call(2));
 	ucv_gc(vm);
 }

--- a/package/network/services/hostapd/src/src/ap/ucode.c
+++ b/package/network/services/hostapd/src/src/ap/ucode.c
@@ -916,7 +916,7 @@ void hostapd_ucode_free(void)
 
 void hostapd_ucode_free_iface(struct hostapd_iface *iface)
 {
-	wpa_ucode_registry_remove(iface_registry, iface->ucode.idx);
+	ucv_put(wpa_ucode_registry_remove(iface_registry, iface->ucode.idx));
 }
 
 void hostapd_ucode_bss_cb(struct hostapd_data *hapd, const char *type)
@@ -950,6 +950,8 @@ void hostapd_ucode_free_bss(struct hostapd_data *hapd)
 	uc_value_push(ucv_string_new(hapd->conf->iface));
 	uc_value_push(ucv_get(val));
 	ucv_put(wpa_ucode_call(2));
+
+	ucv_put(val);
 	ucv_gc(vm);
 }
 

--- a/package/network/services/hostapd/src/src/utils/ucode.c
+++ b/package/network/services/hostapd/src/src/utils/ucode.c
@@ -471,6 +471,7 @@ uc_value_t *wpa_ucode_registry_remove(uc_value_t *reg, int idx)
 	if (!val)
 		return NULL;
 
+	ucv_get(val);
 	ucv_array_set(reg, idx - 1, NULL);
 	dataptr = ucv_resource_dataptr(val, NULL);
 	if (dataptr)

--- a/package/network/services/hostapd/src/src/utils/ucode.c
+++ b/package/network/services/hostapd/src/src/utils/ucode.c
@@ -172,7 +172,7 @@ uc_value_t *uc_wpa_freq_info(uc_vm_t *vm, size_t nargs)
 	ucv_object_add(ret, "op_class", ucv_int64_new(op_class));
 	ucv_object_add(ret, "channel", ucv_int64_new(channel));
 	ucv_object_add(ret, "hw_mode", ucv_int64_new(hw_mode));
-	ucv_object_add(ret, "hw_mode_str", ucv_get(ucv_string_new(modestr)));
+	ucv_object_add(ret, "hw_mode_str", ucv_string_new(modestr));
 	ucv_object_add(ret, "sec_channel", ucv_int64_new(sec_channel));
 	ucv_object_add(ret, "frequency", ucv_int64_new(freq_val));
 

--- a/package/network/services/hostapd/src/src/utils/ucode.c
+++ b/package/network/services/hostapd/src/src/utils/ucode.c
@@ -426,7 +426,7 @@ uc_value_t *wpa_ucode_global_init(const char *name, uc_resource_type_t *global_t
 
 	uc_vm_registry_set(&vm, "hostap.global", global);
 	proto = ucv_prototype_get(global);
-	ucv_object_add(proto, "data", ucv_get(ucv_object_new(&vm)));
+	ucv_object_add(proto, "data", ucv_object_new(&vm));
 
 #define ADD_CONST(x) ucv_object_add(proto, #x, ucv_int64_new(x))
 	ADD_CONST(MSG_EXCESSIVE);

--- a/package/network/services/hostapd/src/wpa_supplicant/ucode.c
+++ b/package/network/services/hostapd/src/wpa_supplicant/ucode.c
@@ -20,7 +20,7 @@ wpas_ucode_iface_get_uval(struct wpa_supplicant *wpa_s)
 	uc_value_t *val;
 
 	if (wpa_s->ucode.idx)
-		return wpa_ucode_registry_get(iface_registry, wpa_s->ucode.idx);
+		return ucv_get(wpa_ucode_registry_get(iface_registry, wpa_s->ucode.idx));
 
 	val = uc_resource_new(iface_type, wpa_s);
 	wpa_s->ucode.idx = wpa_ucode_registry_add(iface_registry, val);
@@ -36,7 +36,7 @@ wpas_ucode_update_interfaces(void)
 	int i;
 
 	for (wpa_s = wpa_global->ifaces; wpa_s; wpa_s = wpa_s->next)
-		ucv_object_add(ifs, wpa_s->ifname, ucv_get(wpas_ucode_iface_get_uval(wpa_s)));
+		ucv_object_add(ifs, wpa_s->ifname, wpas_ucode_iface_get_uval(wpa_s));
 
 	ucv_object_add(ucv_prototype_get(global), "interfaces", ifs);
 	ucv_gc(vm);
@@ -50,7 +50,7 @@ void wpas_ucode_add_bss(struct wpa_supplicant *wpa_s)
 		return;
 
 	uc_value_push(ucv_string_new(wpa_s->ifname));
-	uc_value_push(ucv_get(wpas_ucode_iface_get_uval(wpa_s)));
+	uc_value_push(wpas_ucode_iface_get_uval(wpa_s));
 	ucv_put(wpa_ucode_call(2));
 	ucv_gc(vm);
 }

--- a/package/network/services/hostapd/src/wpa_supplicant/ucode.c
+++ b/package/network/services/hostapd/src/wpa_supplicant/ucode.c
@@ -70,6 +70,7 @@ void wpas_ucode_free_bss(struct wpa_supplicant *wpa_s)
 	uc_value_push(ucv_string_new(wpa_s->ifname));
 	uc_value_push(ucv_get(val));
 	ucv_put(wpa_ucode_call(2));
+	ucv_put(val);
 	ucv_gc(vm);
 }
 

--- a/package/network/services/hostapd/src/wpa_supplicant/ucode.c
+++ b/package/network/services/hostapd/src/wpa_supplicant/ucode.c
@@ -49,7 +49,7 @@ void wpas_ucode_add_bss(struct wpa_supplicant *wpa_s)
 	if (wpa_ucode_call_prepare("iface_add"))
 		return;
 
-	uc_value_push(ucv_get(ucv_string_new(wpa_s->ifname)));
+	uc_value_push(ucv_string_new(wpa_s->ifname));
 	uc_value_push(ucv_get(wpas_ucode_iface_get_uval(wpa_s)));
 	ucv_put(wpa_ucode_call(2));
 	ucv_gc(vm);
@@ -67,7 +67,7 @@ void wpas_ucode_free_bss(struct wpa_supplicant *wpa_s)
 	if (wpa_ucode_call_prepare("iface_remove"))
 		return;
 
-	uc_value_push(ucv_get(ucv_string_new(wpa_s->ifname)));
+	uc_value_push(ucv_string_new(wpa_s->ifname));
 	uc_value_push(ucv_get(val));
 	ucv_put(wpa_ucode_call(2));
 	ucv_gc(vm);
@@ -86,9 +86,9 @@ void wpas_ucode_update_state(struct wpa_supplicant *wpa_s)
 		return;
 
 	state = wpa_supplicant_state_txt(wpa_s->wpa_state);
-	uc_value_push(ucv_get(ucv_string_new(wpa_s->ifname)));
+	uc_value_push(ucv_string_new(wpa_s->ifname));
 	uc_value_push(ucv_get(val));
-	uc_value_push(ucv_get(ucv_string_new(state)));
+	uc_value_push(ucv_string_new(state));
 	ucv_put(wpa_ucode_call(3));
 	ucv_gc(vm);
 }
@@ -108,9 +108,9 @@ void wpas_ucode_event(struct wpa_supplicant *wpa_s, int event, union wpa_event_d
 	if (wpa_ucode_call_prepare("event"))
 		return;
 
-	uc_value_push(ucv_get(ucv_string_new(wpa_s->ifname)));
+	uc_value_push(ucv_string_new(wpa_s->ifname));
 	uc_value_push(ucv_get(val));
-	uc_value_push(ucv_get(ucv_string_new(event_to_string(event))));
+	uc_value_push(ucv_string_new(event_to_string(event)));
 	val = ucv_object_new(vm);
 	uc_value_push(ucv_get(val));
 
@@ -212,15 +212,14 @@ uc_wpas_iface_status(uc_vm_t *vm, size_t nargs)
 {
 	struct wpa_supplicant *wpa_s = uc_fn_thisval("wpas.iface");
 	struct wpa_bss *bss;
-	uc_value_t *ret, *val;
+	uc_value_t *ret;
 
 	if (!wpa_s)
 		return NULL;
 
 	ret = ucv_object_new(vm);
 
-	val = ucv_string_new(wpa_supplicant_state_txt(wpa_s->wpa_state));
-	ucv_object_add(ret, "state", ucv_get(val));
+	ucv_object_add(ret, "state", ucv_string_new(wpa_supplicant_state_txt(wpa_s->wpa_state)));
 
 	bss = wpa_s->current_bss;
 	if (bss) {

--- a/package/network/services/hostapd/src/wpa_supplicant/ucode.c
+++ b/package/network/services/hostapd/src/wpa_supplicant/ucode.c
@@ -38,7 +38,7 @@ wpas_ucode_update_interfaces(void)
 	for (wpa_s = wpa_global->ifaces; wpa_s; wpa_s = wpa_s->next)
 		ucv_object_add(ifs, wpa_s->ifname, ucv_get(wpas_ucode_iface_get_uval(wpa_s)));
 
-	ucv_object_add(ucv_prototype_get(global), "interfaces", ucv_get(ifs));
+	ucv_object_add(ucv_prototype_get(global), "interfaces", ifs);
 	ucv_gc(vm);
 }
 

--- a/package/utils/ucode-mod-pkgen/src/ucode.c
+++ b/package/utils/ucode-mod-pkgen/src/ucode.c
@@ -269,7 +269,7 @@ uc_cert_info(uc_vm_t *vm, size_t nargs)
 		uc_value_t *info = ucv_object_new(vm);
 		int len;
 
-		ucv_array_push(ret, ucv_get(info));
+		ucv_array_push(ret, info);
 		ucv_object_add(info, "version", ucv_int64_new(cur->version));
 
 		uc_cert_info_add_name(info, "issuer", &cur->issuer);

--- a/package/utils/ucode-mod-uline/src/ucode.c
+++ b/package/utils/ucode-mod-uline/src/ucode.c
@@ -153,8 +153,7 @@ uc_uline_get_line(uc_vm_t *vm, size_t nargs)
 		uline_get_line2(&us->s, &line, &len);
 	else
 		uline_get_line(&us->s, &line, &len);
-	val = ucv_string_new_length(line, len);
-	ucv_object_add(state, "line", ucv_get(val));
+	ucv_object_add(state, "line", ucv_string_new_length(line, len));
 	ucv_object_add(state, "pos", ucv_int64_new(us->s.line.pos));
 
 	return state;
@@ -589,7 +588,7 @@ uc_uline_add_pos(uc_vm_t *vm, uc_value_t *list, ssize_t start, ssize_t end)
 	uc_value_t *val = ucv_array_new(vm);
 	ucv_array_push(val, ucv_int64_new(start));
 	ucv_array_push(val, ucv_int64_new(end));
-	ucv_array_push(list, ucv_get(val));
+	ucv_array_push(list, val);
 }
 
 static uc_value_t *
@@ -630,8 +629,8 @@ uc_uline_parse_args(uc_vm_t *vm, size_t nargs, bool check)
 		if (argp->line_sep) {
 			args = ucv_array_new(vm);
 			pos_args = ucv_array_new(vm);
-			ucv_array_push(args, ucv_get(list));
-			ucv_array_push(pos_args, ucv_get(pos_list));
+			ucv_array_push(args, list);
+			ucv_array_push(pos_args, pos_list);
 		} else {
 			args = list;
 			pos_args = pos_list;
@@ -692,10 +691,10 @@ uc_uline_parse_args(uc_vm_t *vm, size_t nargs, bool check)
 
 						buf = NULL;
 						list = ucv_array_new(vm);
-						ucv_array_push(args, ucv_get(list));
+						ucv_array_push(args, list);
 
 						pos_list = ucv_array_new(vm);
-						ucv_array_push(pos_args, ucv_get(pos_list));
+						ucv_array_push(pos_args, pos_list);
 					}
 				}
 				continue;
@@ -751,7 +750,7 @@ uc_uline_parse_args(uc_vm_t *vm, size_t nargs, bool check)
 	}
 
 	if (buf) {
-		ucv_array_push(list, ucv_get(ucv_stringbuf_finish(buf)));
+		ucv_array_push(list, ucv_stringbuf_finish(buf));
 		uc_uline_add_pos(vm, pos_list, start_idx, end_idx);
 	}
 
@@ -762,10 +761,10 @@ uc_uline_parse_args(uc_vm_t *vm, size_t nargs, bool check)
 		return missing;
 
 	ret = ucv_object_new(vm);
-	ucv_object_add(ret, "args", ucv_get(args));
-	ucv_object_add(ret, "pos", ucv_get(pos_args));
+	ucv_object_add(ret, "args", args);
+	ucv_object_add(ret, "pos", pos_args);
 	if (missing)
-		ucv_object_add(ret, "missing", ucv_get(missing));
+		ucv_object_add(ret, "missing", missing);
 
 	return ret;
 }


### PR DESCRIPTION
Thanks for your contribution to OpenWrt!

To help keep the codebase consistent and readable,
and to help people review your contribution,
we ask you to follow the rules you find in the wiki at this link
https://openwrt.org/submitting-patches

Please remove this message before posting the pull request.

## Summary by Sourcery

This pull request updates the ucode integration in hostapd and wpa_supplicant to improve memory management and fix potential memory leaks. It also adds support for the IEEE80211BE standard in hostapd.

New Features:
- Add support for the IEEE80211BE standard in hostapd.

Enhancements:
- Improve memory management by releasing ucode values after use to prevent memory leaks.
- Update ucode integration in hostapd and wpa_supplicant to use the new ucode API.